### PR TITLE
Changed github.com/simonz05/godis to github.com/simonz05/godis/redis in README

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ For installing gorilla/mux do:
 
 for installing godis do:
 
-    $ go get github.com/simonz05/godis
+    $ go get github.com/simonz05/godis/redis
 
 for installing simpleconfig do:
 


### PR DESCRIPTION
The original URL won't install the package, it errors out with this message: `no Go source files in .../src/github.com/simonz05/godis`
